### PR TITLE
Make sure people use nodejs for ExecJS

### DIFF
--- a/config/initializers/execjs_runtime.rb
+++ b/config/initializers/execjs_runtime.rb
@@ -1,0 +1,6 @@
+name = ExecJS.runtime.name
+expected = "Node.js (V8)"
+
+if name != expected
+  raise "Your ExecJS runtime is '#{name}' instead of '#{expected}'. Check README."
+end


### PR DESCRIPTION
On OS X screen.css does not render using JavascriptCore as the backend.
In general it's the best strategy to have developers using the same
setup as in production.

Now tests pass for me so good to go on that part.
