### PR TITLE
Fix modal dialogs on small screens

### DIFF
--- a/app/assets/stylesheets/screen.css.styl
+++ b/app/assets/stylesheets/screen.css.styl
@@ -86,7 +86,11 @@ html, body, #wrapper
 
 body > #wrapper
   height auto
-  min-height 100%
+  min-height 800px
+
+@media (min-height: 800px)
+  body > #wrapper
+    min-height 100%
 
 #content
   width 960px
@@ -831,7 +835,7 @@ a.btn:active, input.btn:active
   min-height 100%
   height auto !important
   height 100%
-  position fixed
+  position absolute
   top 0
   left 0
   background transparent


### PR DESCRIPTION
On small laptop screens the relative positioning of the modal dialogs
could push the larger dialogs out of the screen without showing
scrollbars. This commits makes the body to be always 800 pixels tall. I
tried basing this over the tallest dialog I could locate but due to
unfamiliarity with the application can't be 100% I got it right.
However, when a larger size is needed it's easy to increase the pixel
count.

I tried testing the commit with capybara-webkit but the resize_window
functionality seems to have an open issue in their tracker about not
working properly.
